### PR TITLE
Change behaviour of 'parse' and 'next' functions

### DIFF
--- a/cron-parser-scm-1.rockspec
+++ b/cron-parser-scm-1.rockspec
@@ -29,7 +29,7 @@ build = {
             sources = {'ccronexpr/ccronexpr.c'},
             incdirs = {'ccronexpr'},
         },
-        ['cron.parser'] = 'cron-parser.lua',
+        ['cron.init'] = 'cron-parser.lua',
     }
 }
 

--- a/cron-parser.lua
+++ b/cron-parser.lua
@@ -15,8 +15,9 @@ time_t cron_next(cron_expr* expr, time_t date);
 local ccronexpr = package.search('cron.ccronexpr')
 local cron = ffi.load(ccronexpr)
 
-local parse = function(raw_expr)
+local function parse(raw_expr)
     local parsed_expr = ffi.new("cron_expr[1]")
+
     local err = ffi.new("const char*[1]")
     cron.cron_parse_expr(raw_expr, parsed_expr, err)
 
@@ -24,10 +25,59 @@ local parse = function(raw_expr)
         return nil, ffi.string(err[0])
     end
 
-    return parsed_expr
+    local lua_parsed_expr = {
+        seconds = {},
+        minutes = {},
+        hours = {},
+        days_of_week = nil,
+        days_of_month = {},
+        months = {}
+    }
+
+    for i = 0,7 do
+        lua_parsed_expr.seconds[i + 1] = parsed_expr[0].seconds[i]
+        lua_parsed_expr.minutes[i + 1] = parsed_expr[0].minutes[i]
+    end
+
+    for i = 0,2 do
+        lua_parsed_expr.hours[i + 1] = parsed_expr[0].hours[i]
+    end
+
+    lua_parsed_expr.days_of_week = parsed_expr[0].days_of_week[0]
+
+    for i = 0,3 do
+        lua_parsed_expr.days_of_month[i + 1] = parsed_expr[0].days_of_month[i]
+    end
+
+    for i = 0,1 do
+        lua_parsed_expr.months[i + 1] = parsed_expr[0].months[i]
+    end
+
+    return lua_parsed_expr
 end
 
-local next = function(parsed_expr)
+local function next(lua_parsed_expr)
+    local parsed_expr = ffi.new('cron_expr[1]')
+
+    for i = 0,7 do
+        parsed_expr[0].seconds[i] = lua_parsed_expr.seconds[i + 1]
+        parsed_expr[0].minutes[i] = lua_parsed_expr.minutes[i + 1]
+    end
+
+    for i = 0,2 do
+        parsed_expr[0].hours[i] = lua_parsed_expr.hours[i + 1]
+    end
+
+    parsed_expr[0].days_of_week[0] = lua_parsed_expr.days_of_week
+
+    for i = 0,3 do
+        parsed_expr[0].days_of_month[i] = lua_parsed_expr.days_of_month[i + 1]
+    end
+
+    for i = 0,1 do
+        parsed_expr[0].months[i] = lua_parsed_expr.months[i + 1]
+    end
+
     local ts = cron.cron_next(parsed_expr, os.time())
     return tonumber(ts)
 end

--- a/test.lua
+++ b/test.lua
@@ -1,6 +1,6 @@
 #!/usr/bin/env tarantool
 
-local cron = require('cron.parser')
+local cron = require('cron')
 
 local expr, err = cron.parse('0 */15 * * * *')
 if not expr then


### PR DESCRIPTION
This functions return/take a Lua table instead of a pointer to a struct, now.
