### PR TITLE
Change protocol of rock source

### DIFF
--- a/cron-parser-scm-1.rockspec
+++ b/cron-parser-scm-1.rockspec
@@ -3,7 +3,7 @@ package = 'cron-parser'
 version = 'scm-1'
 
 source  = {
-    url = 'git://github.com/tarantool/cron-parser.git',
+    url = 'https://github.com/tarantool/cron-parser.git',
     branch = 'master'
 }
 


### PR DESCRIPTION
Git protocol is banned from 01.09.2021, so we should use HTTPS protocol.
More information here:
https://github.blog/2021-09-01-improving-git-protocol-security-github/