### PR TITLE
Replace tarantoolctl with tt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ event date.
 
 # Installation
 
-````
-tarantoolctl rocks install cron-parser
-````
+```
+tt rocks install cron-parser
+```
 
 # Example
 


### PR DESCRIPTION
As a part of https://github.com/tarantool/doc/issues/3730, we need to start recommending our users to utilize tt instead of the tarantoolctl utility.